### PR TITLE
An initial pass at exposing the async nature of librdkafka upwards

### DIFF
--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -558,6 +558,20 @@ static VALUE producer_push_single(VALUE self, VALUE message) {
 	return self;
 }
 
+/**
+ * producer_tick
+ *
+ * This function is responsible for ticking the librdkafka reactor so we can
+ * get feedback from the librdkafka threads back into the Ruby environment
+ *
+ *  @param  self	VALUE   the Ruby producer instance
+ *  @param  message VALUE   A Ruby FixNum of how long we should wait on librdkafka
+ */
+static VALUE producer_tick(VALUE self, VALUE timeout) {
+
+	return self;
+}
+
 
 /**
  *  consumer_free
@@ -893,4 +907,7 @@ void Init_hermann_lib() {
 
 	/* Producer.push_single(msg) */
 	rb_define_method(c_producer, "push_single", producer_push_single, 1);
+
+	/* Producer.tick */
+	rb_define_method(c_producer, "tick", producer_tick, 1);
 }

--- a/lib/hermann/errors.rb
+++ b/lib/hermann/errors.rb
@@ -1,0 +1,8 @@
+
+module Hermann
+  module Errors
+    # Error for connectivity problems with the Kafka brokers
+    class ConnectivityError; end;
+  end
+end
+

--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -1,14 +1,18 @@
 require 'hermann'
+require 'hermann/result'
 require 'hermann_lib'
 
 module Hermann
   class Producer
-    attr_reader :topic, :brokers, :internal
+    attr_reader :topic, :brokers, :internal, :children
 
     def initialize(topic, brokers)
       @topic = topic
       @brokers = brokers
       @internal = Hermann::Lib::Producer.new(topic, brokers)
+      # We're tracking children so we can make sure that at Producer exit we
+      # make a reasonable attempt to clean up outstanding result objects
+      @children = []
     end
 
     # Push a value onto the Kafka topic passed to this +Producer+
@@ -16,8 +20,11 @@ module Hermann
     # @param [Array] value An array of values to push, will push each one
     #   separately
     # @param [Object] value A single object to push
-    # @return [Object] the value passed in
+    # @return [Hermann::Result] A future-like object which will store the
+    #   result from the broker
     def push(value)
+      result = create_result
+
       if value.kind_of? Array
         value.each { |element| self.push(element) }
       else
@@ -25,6 +32,28 @@ module Hermann
       end
 
       return value
+    end
+
+    # Create a +Hermann::Result+ that is tracked in the Producer's children
+    # array
+    #
+    # @return [Hermann::Result] A new, unused, result
+    def create_result
+      @children << Hermann::Result.new(self)
+      return @children.last
+    end
+
+    # Tick the underlying librdkafka reacter and clean up any unreaped but
+    # reapable children results
+    #
+    # @return [NilClass]
+    def tick_reactor(timeout=0)
+      # Filter all children who are no longer pending/fulfilled
+      @children = @children.reject { |c| c.reap? }
+
+      # Punt rd_kafka reactor
+      @internal.tick
+      return nil
     end
   end
 end

--- a/lib/hermann/result.rb
+++ b/lib/hermann/result.rb
@@ -1,0 +1,43 @@
+
+module Hermann
+  class Result
+    attr_reader :reason, :state
+
+    STATES = [:pending,
+              :rejected,
+              :fulfilled,
+              :unfulfilled,
+              ].freeze
+
+    def initialize(producer)
+      @producer = producer
+      @reason = nil
+      @value = nil
+      @state = :unfulfilled
+    end
+
+    STATES.each do |state|
+      define_method("#{state}?".to_sym) do
+        return @state == state
+      end
+    end
+
+    # @return [Boolean] True if this child can be reaped
+    def reap?
+      return true if rejected? || fulfilled?
+      return false
+    end
+
+    # INTERNAL METHOD ONLY. Do not use
+    #
+    # This method will be invoked by the underlying extension to indicate set
+    # the actual value after a callback has completed
+    #
+    # @param [Object] value The actual resulting value
+    # @param [Boolean] is_error True if the result was errored for whatever
+    #   reason
+    def set_internal_value(value, is_error)
+      @value = value
+    end
+  end
+end

--- a/spec/hermann_lib/producer_spec.rb
+++ b/spec/hermann_lib/producer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'hermann_lib'
+
+describe Hermann::Lib::Producer do
+  let(:topic) { 'rspec' }
+  let(:brokers) { 'localhost:1337' }
+  subject(:producer) { described_class.new(topic, brokers) }
+
+  it { should respond_to :push_single }
+  it { should respond_to :tick }
+end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'hermann/result'
+
+describe Hermann::Result do
+  let(:producer) { double('Mock Hermann::Producer') }
+  subject(:result) { described_class.new(producer) }
+
+  describe '#reap?' do
+    subject { result.reap? }
+
+    context 'if state == :pending' do
+      before(:each) { allow(result).to receive(:pending?) { true } }
+      it { should be false }
+    end
+
+    context 'if state == :unfulfilled' do
+      before(:each) { allow(result).to receive(:unfulfilled?) { true } }
+      it { should be false }
+    end
+
+    context 'if state == :fulfilled' do
+      before(:each) { allow(result).to receive(:fulfilled?) { true } }
+      it { should be true}
+    end
+
+    context 'if state == :rejected' do
+      before(:each) { allow(result).to receive(:rejected?) { true } }
+      it { should be true}
+    end
+  end
+
+  describe '#rejected?' do
+    subject { result.rejected? }
+
+    context' by default' do
+      it { should be false }
+    end
+  end
+
+  describe '#pending?' do
+    subject { result.pending? }
+
+    context' by default' do
+      it { should be false }
+    end
+  end
+end


### PR DESCRIPTION
This should be enough to get some initial review of the API going. Hooking up a
Hermann::Result class to the Hermann::Producer in Ruby is in this commit but
actually driving the librdkafka reactor underneath is not yet hooked up.

Fixes #11
Fixes #15
Fixes #18 

We can either merge this early, or wait until I add the hook-up to librdkafka
