### PR TITLE
Avoid call to rb_string_value_cstr() which doesn't handle binary strings properly

### DIFF
--- a/ext/hermann/hermann_lib.c
+++ b/ext/hermann/hermann_lib.c
@@ -573,11 +573,13 @@ static VALUE producer_push_single(VALUE self, VALUE message, VALUE result) {
 		TRACER("setting result: %p\n", result);
 	}
 
+	TRACER("rd_kafka_produce() message of %i bytes\n", RSTRING_LEN(message));
+
 	/* Send/Produce message. */
 	if (-1 == rd_kafka_produce(producerConfig->rkt,
 						 producerConfig->partition,
 						 RD_KAFKA_MSG_F_COPY,
-						 rb_string_value_cstr(&message),
+						 RSTRING_PTR(message),
 						 RSTRING_LEN(message),
 						 NULL,
 						 0,

--- a/spec/hermann_lib/producer_spec.rb
+++ b/spec/hermann_lib/producer_spec.rb
@@ -68,7 +68,7 @@ describe Hermann::Lib::Producer do
     end
 
     context 'with binary data' do
-      let(:message) { "\n+AuOzetQrTrdwSY14ig7I_1oUwjp3DvTx3YWhSTGD4Fo\022\0312014-09-10T00:18:47-07:00\032,\n\006scream\022\016missing_device\032\022app0\"\t\n\astarted*(\b\000\022$009f0305-b50a-455d-b137-e52b45f674aa*(\b\001\022$53c0d817-d94b-4b7a-9a58-95fe8cec4333" }
+      let(:message) { "\n+AuOzetQrTrdwSY14ig7I_1oUwjp3DvTx3YWhSTGD4Fo\022\0312014-09-10T00:18:47-07:00\032,\n\006scream\022\016missing_device\032\022flexd-today-0-app0\"\t\n\astarted*(\b\000\022$009f0305-b50a-455d-b137-e52b45f674aa*(\b\001\022$53c0d817-d94b-4b7a-9a58-95fe8cec4333" }
 
       it 'should return' do
         expect(push).not_to be_nil


### PR DESCRIPTION
I believe this is all that's necessary to resolve #32 

I've done some manual testing to validate that we're sending the right bytes through Kafka, in the integration test I printed out the md5 of the byte string going in, and then printed the md5 of the buffer that a Kafka consumer (using the Java Kafka library) reads off:

**producer side**

```
Hermann::Lib::Producer
  #push_single
    with binary data
hash: a3e3316785491f09d90fd57b2d412437
      should return
```

**consumer side**

```
"\n+AuOzetQrTrdwSY14ig7I_1oUwjp3DvTx3YWhSTGD4Fo\x12\x192014-09-10T00:18:47-07:00\x1A,\n\x06scream\x12\x0Emissing_device\x1A\x12flexd-today-0-app0\"\t\n\astarted*(\b\x00\x12$009f0305-b50a-455d-b137-e52b45f674aa*(\b\x01\x12$53c0d817-d94b-4b7a-9a58-95fe8cec4333"
Hash: a3e3316785491f09d90fd57b2d412437
Read: 213 from Kafka
```
