### PR TITLE
Push method returns executing Promise

### DIFF
--- a/lib/hermann/provider/java_producer.rb
+++ b/lib/hermann/provider/java_producer.rb
@@ -37,7 +37,7 @@ module Hermann
       #   data to the kafka broker.  Upon execution the Promise's status
       #   will be set
       def push_single(msg)
-        Concurrent::Promise.new {
+        Concurrent::Promise.execute {
           data = ProducerUtil::KeyedMessage.new(@topic, msg)
           @producer.send(data)
         }

--- a/spec/providers/java_producer_spec.rb
+++ b/spec/providers/java_producer_spec.rb
@@ -13,7 +13,7 @@ describe Hermann::Provider::JavaProducer do
     context 'error conditions' do
       shared_examples 'an error condition' do
         it 'should be rejected' do
-          promise = producer.push_single('rspec').execute.wait(1)
+          promise = producer.push_single('rspec').wait(1)
           expect(promise).to be_rejected
           expect { promise.value! }.to raise_error
         end


### PR DESCRIPTION
JavaProducer push method now returns an executing promise instead of requiring an explicit call to execute.

```
p = Hermann::Producer.new('test', '0:9092')
promise = p.push("test123")  #promise is executing
sleep 2
```
