### PR TITLE
Allow java producer push to change topics

### DIFF
--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -16,7 +16,7 @@ module Hermann
       @topic = topic
       @brokers = brokers
       if RUBY_PLATFORM == "java"
-        @internal = Hermann::Provider::JavaProducer.new(topic, brokers)
+        @internal = Hermann::Provider::JavaProducer.new(brokers)
       else
         @internal = Hermann::Lib::Producer.new(topic, brokers)
       end
@@ -45,16 +45,21 @@ module Hermann
     # @param [Array] value An array of values to push, will push each one
     #   separately
     # @param [Object] value A single object to push
+    #
+    # @param [Hash] opts to pass to push method
+    # @params opts [String] :topic The topic to push messages to
+    #
     # @return [Hermann::Result] A future-like object which will store the
     #   result from the broker
-    def push(value)
+    def push(value, opts={})
+      topic = opts[:topic] || @topic
       result = create_result
 
       if value.kind_of? Array
         return value.map { |e| self.push(e) }
       else
         if RUBY_PLATFORM == "java"
-          result = @internal.push_single(value)
+          result = @internal.push_single(value, topic)
           @children << result
         else
           @internal.push_single(value, result)

--- a/lib/hermann/provider/java_producer.rb
+++ b/lib/hermann/provider/java_producer.rb
@@ -10,10 +10,9 @@ module Hermann
     # will raise the exception and the rejected flag will be set to true
     #
     class JavaProducer
-      attr_accessor :topic, :producer
+      attr_accessor :producer
 
-      def initialize(topic, brokers)
-        @topic      = topic
+      def initialize(brokers)
         properties  = create_properties(:brokers => brokers)
         config      = create_config(properties)
         @producer   = JavaApiUtil::Producer.new(config)
@@ -28,13 +27,14 @@ module Hermann
       # Push a value onto the Kafka topic passed to this +Producer+
       #
       # @param [Object] value A single object to push
+      # @param [String] topic to push message to
       #
       # @return +Concurrent::Promise+ Representa a promise to send the
       #   data to the kafka broker.  Upon execution the Promise's status
       #   will be set
-      def push_single(msg)
+      def push_single(msg, topic)
         Concurrent::Promise.execute {
-          data = ProducerUtil::KeyedMessage.new(@topic, msg)
+          data = ProducerUtil::KeyedMessage.new(topic, msg)
           @producer.send(data)
         }
       end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -19,6 +19,23 @@ describe Hermann::Producer do
         expect(producer.children).to_not be_empty
       end
     end
+
+    describe '#push' do
+      let(:msg)   { 'foo' }
+      let(:passed_topic) { 'bar' }
+      context 'without topic passed' do
+        it 'uses initialized topic' do
+          expect_any_instance_of(Hermann::Provider::JavaProducer).to receive(:push_single).with(msg, topic)
+          producer.push(msg)
+        end
+      end
+      context 'with topic passed' do
+        it 'can change topic' do
+          expect_any_instance_of(Hermann::Provider::JavaProducer).to receive(:push_single).with(msg, passed_topic)
+          producer.push(msg, :topic => passed_topic)
+        end
+      end
+    end
   end
 
   context "not java", :platform => :mri do


### PR DESCRIPTION
If no message is passed to push method, then topic from initialization is used
If a topic is passed to push method, then that topic is used
