### PR TITLE
allow user to pass in opts

### DIFF
--- a/lib/hermann/discovery/zookeeper.rb
+++ b/lib/hermann/discovery/zookeeper.rb
@@ -1,10 +1,11 @@
 require 'hermann'
 require 'zk'
 require 'json'
+require 'hermann/errors'
 
 module Hermann
   module Discovery
-    class NoBrokersError < StandardError; end
+
 
     # Communicates with Zookeeper to discover kafka broker ids
     #
@@ -24,12 +25,16 @@ module Hermann
       #    of 20 times the tickTime2 times the tick time set on server"
       #
       # @return [String] comma separated list of brokers
+      #
+      # @raises [NoBrokersError] if could not discover brokers thru zookeeper
       def get_brokers(timeout=0)
         brokers = []
         ZK.open(zookeepers, {:timeout => timeout}) do |zk|
           brokers = fetch_brokers(zk)
         end
-        raise NoBrokersError if brokers.empty?
+        if brokers.empty?
+          raise Hermann::Errors::NoBrokersError
+        end
         brokers.join(',')
       end
 

--- a/lib/hermann/errors.rb
+++ b/lib/hermann/errors.rb
@@ -3,6 +3,12 @@ module Hermann
   module Errors
     # Error for connectivity problems with the Kafka brokers
     class ConnectivityError; end;
+
+    # For passing incorrect config and options to kafka
+    class ConfigurationError < StandardError; end
+
+    # cannot discover brokers from zookeeper
+    class NoBrokersError < StandardError; end
   end
 end
 

--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -16,11 +16,11 @@ module Hermann
     #
     # @param [String] topic The default topic to use for pushing messages
     # @param [Array] brokers An array of "host:port" strings for the brokers
-    def initialize(topic, brokers)
+    def initialize(topic, brokers, opts={})
       @topic = topic
       @brokers = brokers
       if RUBY_PLATFORM == "java"
-        @internal = Hermann::Provider::JavaProducer.new(brokers)
+        @internal = Hermann::Provider::JavaProducer.new(brokers, opts)
       else
         @internal = Hermann::Lib::Producer.new(brokers)
       end
@@ -130,7 +130,7 @@ module Hermann
     end
 
     # Perform the actual reactor tick
-    # @raises [StandardError[ in case of underlying failures in librdkafka
+    # @raises [StandardError] in case of underlying failures in librdkafka
     def execute_tick(timeout)
       if timeout == 0
         @internal.tick(0)

--- a/lib/hermann/version.rb
+++ b/lib/hermann/version.rb
@@ -1,3 +1,3 @@
 module Hermann
-  VERSION = '0.17.0'
+  VERSION = '0.18.0'
 end

--- a/spec/discovery/zookeeper_spec.rb
+++ b/spec/discovery/zookeeper_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'hermann/discovery/zookeeper'
+require 'hermann/errors'
 
 describe Hermann::Discovery::Zookeeper do
   let(:zk) { double }
@@ -10,10 +11,21 @@ describe Hermann::Discovery::Zookeeper do
 
   describe '#get_brokers' do
     let(:broker_array) { ['f:1','a:2'] }
-    it 'gets a conna separated string of brokers' do
+    before do
       allow(ZK).to receive(:open).with(any_args).and_yield(zk)
-      allow(subject).to receive(:fetch_brokers).with(any_args) { broker_array }
-      expect(subject.get_brokers).to eq 'f:1,a:2'
+      allow(subject).to receive(:fetch_brokers).with(any_args) { brokers }
+    end
+    context 'with valid brokers' do
+      let(:brokers) { broker_array }
+      it 'gets valid string' do
+        expect(subject.get_brokers).to eq 'f:1,a:2'
+      end
+    end
+    context 'with no brokers' do
+      let(:brokers) { [] }
+      it 'raises an error' do
+        expect{ subject.get_brokers }.to raise_error(Hermann::Errors::NoBrokersError)
+      end
     end
   end
 

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 require 'hermann/producer'
 
 describe Hermann::Producer do
-  subject(:producer) { described_class.new(topic, brokers) }
+  subject(:producer) { described_class.new(topic, brokers, opts) }
 
   let(:topic) { 'rspec' }
   let(:brokers) { 'localhost:1337' }
+  let(:opts) { { 'request.required.acks' => '1' } }
 
   describe '#create_result' do
     subject { producer.create_result }


### PR DESCRIPTION
_Example Hash_

``` ruby
opts = {
  'serializer.class'      => 'kafka.serializer.StringEncoder',
  'partitioner.class'     => 'kafka.producer.DefaultPartitioner',
  'request.required.acks' => '1'
}

Hermann::Provider::JavaProducer.new(broker_ids, opts)
```

Issue #52 
