### PR TITLE
Pass string to JavaProducer

### DIFF
--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -21,7 +21,7 @@ module Hermann
       @topic = topic
       @brokers = ThreadSafe::Array.new(brokers)
       if Hermann.jruby?
-        @internal = Hermann::Provider::JavaProducer.new(brokers, opts)
+        @internal = Hermann::Provider::JavaProducer.new(brokers.join(','), opts)
       else
         @internal = Hermann::Lib::Producer.new(brokers.join(','))
       end

--- a/lib/hermann/version.rb
+++ b/lib/hermann/version.rb
@@ -1,3 +1,3 @@
 module Hermann
-  VERSION = '0.19.0'
+  VERSION = '0.19.1'
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -8,6 +8,21 @@ describe Hermann::Producer do
   let(:brokers) { ['localhost:1337'] }
   let(:opts) { { 'request.required.acks' => '1' } }
 
+  describe '#initialize' do
+    context 'with C ruby', :platform => :mri do
+      it 'joins broker array' do
+        expect(Hermann::Lib::Producer).to receive(:new).with(brokers.first)
+        expect(producer).to be_a Hermann::Producer
+      end
+    end
+    context 'with Java', :platform => :java do
+      it 'joins broker array' do
+        expect(Hermann::Provider::JavaProducer).to receive(:new).with(brokers.first, opts)
+        expect(producer).to be_a Hermann::Producer
+      end
+    end
+  end
+
   describe '#create_result' do
     subject { producer.create_result }
 


### PR DESCRIPTION
Code fails to join the brokers array into a string.  JavaProducer expects a broker string.

bumps version to 0.19.1
#68
