### PR TITLE
fixup exception handling in consumer

### DIFF
--- a/lib/hermann/consumer.rb
+++ b/lib/hermann/consumer.rb
@@ -21,11 +21,9 @@ module Hermann
     #
     # @params [String] comma separated zookeeper list
     #
-    # @params [Hash] options for consumer
+    # @params [Hash] options for Consumer
     # @option opts [String] :brokers   (for MRI) Comma separated list of brokers
     # @option opts [String] :partition (for MRI) The kafka partition
-    # @option opts [Fixnum]  :sleep_time (Jruby) Time to sleep between consume retries, defaults to 1sec
-    # @option opts [Boolean] :do_retry (Jruby) Retry consume attempts if exceptions are thrown, defaults to true
     def initialize(topic, groupId, zookeepers, opts={})
       @topic = topic
       @brokers = brokers

--- a/lib/hermann_jars.rb
+++ b/lib/hermann_jars.rb
@@ -1,15 +1,15 @@
 # this is a generated file, to avoid over-writing it just delete this comment
 require 'jar_dependencies'
 
-require_jar( 'junit', 'junit', '3.8.1' )
-require_jar( 'com.101tec', 'zkclient', '0.3' )
-require_jar( 'com.yammer.metrics', 'metrics-core', '2.2.0' )
 require_jar( 'log4j', 'log4j', '1.2.17' )
-require_jar( 'jline', 'jline', '0.9.94' )
-require_jar( 'net.sf.jopt-simple', 'jopt-simple', '3.2' )
-require_jar( 'org.apache.zookeeper', 'zookeeper', '3.3.4' )
-require_jar( 'org.mod4j.org.eclipse.xtext', 'log4j', '1.2.15' )
 require_jar( 'org.slf4j', 'slf4j-api', '1.7.2' )
-require_jar( 'org.apache.kafka', 'kafka_2.10', '0.8.1.1' )
 require_jar( 'org.scala-lang', 'scala-library', '2.10.1' )
+require_jar( 'com.yammer.metrics', 'metrics-core', '2.2.0' )
+require_jar( 'org.apache.zookeeper', 'zookeeper', '3.3.4' )
+require_jar( 'net.sf.jopt-simple', 'jopt-simple', '3.2' )
+require_jar( 'org.apache.kafka', 'kafka_2.10', '0.8.1.1' )
+require_jar( 'jline', 'jline', '0.9.94' )
+require_jar( 'com.101tec', 'zkclient', '0.3' )
+require_jar( 'org.mod4j.org.eclipse.xtext', 'log4j', '1.2.15' )
+require_jar( 'junit', 'junit', '3.8.1' )
 require_jar( 'org.xerial.snappy', 'snappy-java', '1.0.5' )

--- a/spec/integration/producer_spec.rb
+++ b/spec/integration/producer_spec.rb
@@ -29,14 +29,14 @@ describe 'producer' do
       next value
     end
   end
-  let(:brokers) do
+  let(:broker_ids) do
     broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
+    puts ""
     puts "using ZK discovered brokers: #{broker_ids}"
+    puts ""
     broker_ids
   end
-  let(:producer) { Hermann::Producer.new(nil, brokers) }
-
-
+  let(:producer) { Hermann::Producer.new(nil, broker_ids) }
 
   it 'produces and consumes messages', :type => :integration, :platform => :java do
     producer.push(message, :topic => topic).value!(timeout)
@@ -48,7 +48,7 @@ describe 'producer' do
     let(:event) do
       Hermann::TestEvent.new(:name => 'rspec',
                              :state => 3,
-                            :bogomips => 9001)
+                             :bogomips => 9001)
     end
 
     let(:message) { event.encode }


### PR DESCRIPTION
- catch StandardError
- allow retrying a configurable fixed number of times
- add logger support
#72
