### PR TITLE
Fix MRI documentation in consumer.rb

### DIFF
--- a/lib/hermann/consumer.rb
+++ b/lib/hermann/consumer.rb
@@ -23,7 +23,7 @@ module Hermann
     #
     # @params [Hash] options for Consumer
     # @option opts [String] :brokers   (for MRI) Comma separated list of brokers
-    # @option opts [String] :partition (for MRI) The kafka partition
+    # @option opts [Integer] :partition (for MRI) The kafka partition
     def initialize(topic, groupId, zookeepers, opts={})
       @topic = topic
       @brokers = brokers


### PR DESCRIPTION
Seems like it's supposed to be an int, not a string after all

```
2.1.5 :014 > the_consumer = Hermann::Consumer.new(topic, groupId, zookeepers, {:brokers => '1', :partition => '0'})
TypeError: no implicit conversion of String into Integer
    from /Users/mseeger/.rvm/gems/ruby-2.1.5/gems/hermann-0.20.1/lib/hermann/consumer.rb:37:in `initialize'
    from /Users/mseeger/.rvm/gems/ruby-2.1.5/gems/hermann-0.20.1/lib/hermann/consumer.rb:37:in `new'
    from /Users/mseeger/.rvm/gems/ruby-2.1.5/gems/hermann-0.20.1/lib/hermann/consumer.rb:37:in `initialize'
    from (irb):14:in `new'
    from (irb):14
    from /Users/mseeger/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
2.1.5 :015 > the_consumer = Hermann::Consumer.new(topic, groupId, zookeepers, {:brokers => '1', :partition => 0})
 => #<Hermann::Consumer:0x007ff540a16548 @topic="hydra.zerg", @brokers=nil, @partition=nil, @internal=#<Hermann::Lib::Consumer:0x007ff540a164f8>> 
```
