### PR TITLE
Update jar-dependencies version

### DIFF
--- a/hermann.gemspec
+++ b/hermann.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
     # IMPORTANT: make sure that jar-dependencies is only a development
     # dependency of your gem. if it is a runtime dependencies the require_jars
     # file will be overwritten during installation.
-    s.add_dependency 'jar-dependencies', ['~> 0.1', '>= 0.1.10']
+    s.add_dependency 'jar-dependencies', '~> 0.4'
     s.requirements << "jar org.apache.kafka:kafka_2.11, ~> 0.8.2.2"
     # use log4j-1.2.16+ to as 1.2.15 declares deps which are not in maven central and causes the dep resolution to fail
     s.requirements << "jar log4j:log4j, ~> 1.2.16"

--- a/lib/hermann/version.rb
+++ b/lib/hermann/version.rb
@@ -1,3 +1,3 @@
 module Hermann
-  VERSION = '0.26.1'
+  VERSION = '0.27.0'
 end


### PR DESCRIPTION
Update jar-dependencies vaersion and unpin it somewhat, so that things don't explode when you
have transitive deps. Who pins libraries to specific versions
of things? That way madness lies.